### PR TITLE
cl907d-cl987d: Document core CSC methods

### DIFF
--- a/classes/display/cl907d.h
+++ b/classes/display/cl907d.h
@@ -1212,6 +1212,30 @@ extern "C" {
 #define NV907D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV907D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV907D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV907D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV907D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV907D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV907D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV907D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV907D_HEAD_SET_DISPLAY_ID(a,b)                                         (0x0000052C + (a)*0x00000300 + (b)*0x00000004)
 #define NV907D_HEAD_SET_DISPLAY_ID_CODE                                         31:0
 #define NV907D_HEAD_SET_SW_SPARE_A(a)                                           (0x0000054C + (a)*0x00000300)

--- a/classes/display/cl917d.h
+++ b/classes/display/cl917d.h
@@ -1231,6 +1231,30 @@ extern "C" {
 #define NV917D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV917D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV917D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV917D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV917D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV917D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV917D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV917D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV917D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV917D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV917D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)

--- a/classes/display/cl927d.h
+++ b/classes/display/cl927d.h
@@ -1236,6 +1236,30 @@ extern "C" {
 #define NV927D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV927D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV927D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV927D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV927D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV927D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV927D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV927D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV927D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV927D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV927D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)

--- a/classes/display/cl947d.h
+++ b/classes/display/cl947d.h
@@ -1233,6 +1233,30 @@ extern "C" {
 #define NV947D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV947D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV947D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV947D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV947D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV947D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV947D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV947D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV947D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV947D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV947D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)

--- a/classes/display/cl957d.h
+++ b/classes/display/cl957d.h
@@ -1229,6 +1229,30 @@ extern "C" {
 #define NV957D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV957D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV957D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV957D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV957D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV957D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV957D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV957D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV957D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV957D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV957D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)

--- a/classes/display/cl977d.h
+++ b/classes/display/cl977d.h
@@ -1214,6 +1214,30 @@ extern "C" {
 #define NV977D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV977D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV977D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV977D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV977D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV977D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV977D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV977D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV977D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV977D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV977D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)

--- a/classes/display/cl987d.h
+++ b/classes/display/cl987d.h
@@ -1217,6 +1217,30 @@ extern "C" {
 #define NV987D_HEAD_SET_CONVERSION_BLU(a)                                       (0x000004EC + (a)*0x00000300)
 #define NV987D_HEAD_SET_CONVERSION_BLU_GAIN                                     15:0
 #define NV987D_HEAD_SET_CONVERSION_BLU_OFS                                      31:16
+#define NV987D_HEAD_SET_CSC_RED2RED(a)                                          (0x000004F0 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_RED2RED_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_GRN2RED(a)                                          (0x000004F4 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_GRN2RED_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_BLU2RED(a)                                          (0x000004F8 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_BLU2RED_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_CONSTANT2RED(a)                                     (0x000004FC + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_CONSTANT2RED_COEFF                                  18:0
+#define NV987D_HEAD_SET_CSC_RED2GRN(a)                                          (0x00000500 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_RED2GRN_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_GRN2GRN(a)                                          (0x00000504 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_GRN2GRN_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_BLU2GRN(a)                                          (0x00000508 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_BLU2GRN_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_CONSTANT2GRN(a)                                     (0x0000050C + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_CONSTANT2GRN_COEFF                                  18:0
+#define NV987D_HEAD_SET_CSC_RED2BLU(a)                                          (0x00000510 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_RED2BLU_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_GRN2BLU(a)                                          (0x00000514 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_GRN2BLU_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_BLU2BLU(a)                                          (0x00000518 + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_BLU2BLU_COEFF                                       18:0
+#define NV987D_HEAD_SET_CSC_CONSTANT2BLU(a)                                     (0x0000051C + (a)*0x00000300)
+#define NV987D_HEAD_SET_CSC_CONSTANT2BLU_COEFF                                  18:0
 #define NV987D_HEAD_SET_HDMI_CTRL(a)                                            (0x00000520 + (a)*0x00000300)
 #define NV987D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT                                  2:0
 #define NV987D_HEAD_SET_HDMI_CTRL_VIDEO_FORMAT_NORMAL                           (0x00000000)


### PR DESCRIPTION
I figured why wait for an answer, when you can just find the answer
yourself :). This should add what I'm fairly sure are the methods for
setting the CSC matrix for the core surface. I've tested them locally on
one of my Pascal GPUs and they seem to work just fine. Since these are
reverse engineered though, it'd be appreciated if someone from Nvidia could
verify these are correct.