### PR TITLE
use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ please see the "github pages" view, here:
 
 This content was originally kept at:
 
-    http://download.nvidia.com/open-gpu-doc/
+    https://download.nvidia.com/open-gpu-doc/
 
 ...but has been moved to github, mainly for easier version tracking. Some of
 these documents get updates and errata, and the above site was forced to create
 separate subdirectories for any updates. For example:
 
-    http://download.nvidia.com/open-gpu-doc/Display-Class-Methods/1
-    http://download.nvidia.com/open-gpu-doc/Display-Class-Methods/2
+    https://download.nvidia.com/open-gpu-doc/Display-Class-Methods/1
+    https://download.nvidia.com/open-gpu-doc/Display-Class-Methods/2
 
 Instead of the above, you can now just browse the git commit log.
 


### PR DESCRIPTION
Why are we still using http instead of https in 2022

Also thank you for this documentation! We do appreciate it 🙂 